### PR TITLE
use prefered parameters for actions/create-github-app-token

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1 # v1.10.0
         id: generate_token
         with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
`app_id` and `private_key` of actions/create-github-app-token are deprecated.
https://github.com/actions/create-github-app-token/blob/d9bc16919cdbdb07543eb732aa872437384e296f/action.yml#L14